### PR TITLE
Automation/scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ node_modules/
 # Intellij
 .idea
 
+
+scrapper/data/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,32 @@ Python solution to extract the courses schedules from the different Faculties of
 - Wait for MySQL to initialize
 - `docker-compose run scrapper bash`
 ### Scrapper image
-- `scrapy crawl faculties`
-- `export YEAR=2019` (Replace 2019 here with the lowest value in the two-year bound - for example, 2019-2020 is 2019)
-- `scrapy crawl courses`
-- `scrapy crawl course_units -a user=up123456789`
-- `scrapy crawl schedules -a user=up123456789`
+The scrapper image is responsible for populating the databases, generating `.sql` files and store this information at `scrapper/data/`. 
 
-To inspect the scrapy engine, use `scrapy shell "url"`
+#### Quick start
+To scrap the data execute: 
+
+- `export YEAR=2019` (Replace 2019 here with the lowest value in the two-year bound- for example, 2019-2020 is 2019)
+- `export USER=up201812345` (Replace the value by your up number)
+- `make clean`
+- `make`
+
+
+These commands are equivalent to execute:
+
+- **Clean** 
+    - `rm -r scrapper/data`
+    - `mkdir scrapper/data`
+
+- **Scrap**
+    - `scrapy crawl faculties`
+    - `export YEAR=2019` (Replace 2019 here with the lowest value in the two-year bound - for example, 2019-2020 is 2019)
+    - `scrapy crawl courses`
+    - `scrapy crawl course_units -a user=up123456789`
+    - `scrapy crawl schedules -a user=up123456789`
+
+#### Inspection 
+To inspect the scrapy engine, use `scrapy shell "url"`: 
 
 Example:
 ```
@@ -29,3 +48,21 @@ root@00723f950c71:/scrapper# scrapy shell "https://sigarra.up.pt/fcnaup/pt/cur_g
 63480
 >>> response.xpath('//*[@id="anos_curr_div"]/div').extract()
 ```
+
+#### Upload
+
+To upload the data to a temporary storage execute: 
+
+- `make upload`
+
+Output example: 
+
+```json
+{"status":"success","data":{"url":"https://tmpfiles.org/30588/1_faculty.sql"}}
+{"status":"success","data":{"url":"https://tmpfiles.org/30589/2_course.sql"}}
+{"status":"success","data":{"url":"https://tmpfiles.org/30590/3_course_unit.sql"}}
+{"status":"success","data":{"url":"https://tmpfiles.org/30591/4_schedule.sql"}}
+```
+
+The data can be downloaded in the given url. 
+> :warning: After one hour the data will be deleted. 

--- a/scrapper/Makefile
+++ b/scrapper/Makefile
@@ -1,0 +1,20 @@
+.PHYONY: all clean 
+
+all: scrapy 
+
+scrapy:
+	@-mkdir ./data/
+	scrapy crawl faculties
+	export YEAR=${YEAR}
+	scrapy crawl courses
+	scrapy crawl course_units -a user=${USER}
+	scrapy crawl schedules -a user=${USER}
+
+upload: 
+	@echo [UPLOADING] files...
+	@python scripts/upload.py
+
+clean: 
+	@echo [CLEANING] files from scrapper... 
+	@-rm -r ./data/
+

--- a/scrapper/config.ini
+++ b/scrapper/config.ini
@@ -1,0 +1,13 @@
+[paths]
+db_files=./data
+
+[files]
+faculty = ${paths:db_files}/1_faculty.sql
+course = ${paths:db_files}/2_course.sql 
+course_unit = ${paths:db_files}/3_course_unit.sql
+schedule = ${paths:db_files}/4_schedule.sql 
+
+[upload]
+url=https://tmpfiles.org/api/v1/upload
+param_name=file
+path=./data

--- a/scrapper/scrapper/pipelines.py
+++ b/scrapper/scrapper/pipelines.py
@@ -8,26 +8,45 @@ import json
 import pymysql
 from . import items
 from .con_info import ConInfo
+from configparser import ConfigParser, ExtendedInterpolation
+
+config_file = "./config.ini"
+config = ConfigParser(interpolation=ExtendedInterpolation())
+config.read(config_file)
 
 
 class MySQLPipeline(ConInfo):
     def process_item(self, item, spider):
         return item
 
+    """
+        Saves the scrapped information in a specific file, so it can be easily exported. 
+    """
+    def save2file(self, item, prepared):
+        try:
+            values = tuple(map(lambda x: "\'{}\'".format(x), item.values()))
+            self.sql_file.write(prepared % values + ";\n")           
+        except Exception as e:
+            print(e)
+
 
 class FacultyPipeline(MySQLPipeline):
     def __init__(self):
         MySQLPipeline.__init__(self)
+        self.sql_file = open(config['files']['faculty'], 'a')
 
     def process_item(self, item, spider):
         if not isinstance(item, items.Faculty):
             return item
         sql = "INSERT INTO `{0}` (`{1}`) VALUES ({2})"
         prepared = sql.format('faculty', "`, `".join(item.keys()), ", ".join("%s" for _ in item.values()))
+        self.save2file(item, prepared)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(prepared, tuple(item.values()))
                 self.connection.commit()
+        except Exception as e:
+            print(e)
         finally:
             return item
 
@@ -35,6 +54,7 @@ class FacultyPipeline(MySQLPipeline):
 class CoursePipeline(MySQLPipeline):
     def __init__(self):
         MySQLPipeline.__init__(self)
+        self.sql_file = open(config['files']['course'], 'a')
 
     def process_item(self, item, spider):
         if not isinstance(item, items.Course):
@@ -43,10 +63,13 @@ class CoursePipeline(MySQLPipeline):
         columns = "`, `".join(item.keys())
         values = ", ".join("%s" for _ in item.values())
         prepared = sql.format('course', columns, values)
+        self.save2file(item, prepared)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(prepared, tuple(item.values()))
                 self.connection.commit()
+        except Exception as e:
+            print(e)
         finally:
             return item
 
@@ -54,6 +77,7 @@ class CoursePipeline(MySQLPipeline):
 class CourseUnitPipeline(MySQLPipeline):
     def __init__(self):
         MySQLPipeline.__init__(self)
+        self.sql_file = open(config['files']['course_unit'], 'a')
 
     def process_item(self, item, spider):
         if not isinstance(item, items.CourseUnit):
@@ -62,10 +86,13 @@ class CourseUnitPipeline(MySQLPipeline):
         columns = "`, `".join(key for key in item.keys())
         values = ", ".join("%s" for _ in item.values())
         prepared = sql.format('course_unit', columns, values)
+        self.save2file(item, prepared)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(prepared, tuple(item.values()))
                 self.connection.commit()
+        except Exception as e:
+            print(e)
         finally:
             return item
 
@@ -73,6 +100,7 @@ class CourseUnitPipeline(MySQLPipeline):
 class SchedulePipeline(MySQLPipeline):
     def __init__(self):
         MySQLPipeline.__init__(self)
+        self.sql_file = open(config['files']['schedule'], 'a')
 
     def process_item(self, item, spider):
         if not isinstance(item, items.Schedule):
@@ -81,9 +109,12 @@ class SchedulePipeline(MySQLPipeline):
         columns = "`, `".join(item.keys())
         values = ", ".join("%s" for _ in item.values())
         prepared = sql.format('schedule', columns, values)
+        self.save2file(item, prepared)
         try:
             with self.connection.cursor() as cursor:
                 cursor.execute(prepared, tuple(item.values()))
                 self.connection.commit()
+        except Exception as e:
+            print(e)
         finally:
             return item

--- a/scrapper/scripts/upload.py
+++ b/scrapper/scripts/upload.py
@@ -1,0 +1,23 @@
+from distutils.command.config import config
+import requests 
+import configparser 
+from os import listdir
+
+
+def upload_files(config: configparser.ConfigParser):
+    url = config["upload"]["url"]
+    
+    param_name = config["upload"]["param_name"]
+    path = config["upload"]["path"]
+    files = [f for f in listdir(path)]
+    for f in files: 
+        filepath = "{}/{}".format(path, f)
+        files = {param_name: open(filepath, "rb")}
+        r = requests.post(url, files=files)
+        print(r.text)
+        
+
+
+config = configparser.ConfigParser()
+config.read("./config.ini") 
+upload_files(config)


### PR DESCRIPTION
# 💡 Additions 

- [x] Added makefile to automate the scrapping command line; 
- [x] Pipelines now also creates .sql files to ease the exportation to another database; 
- [x] Upload script was created and associated to the makefile.  The script uploads the `.sql` file to an online storage, which can be retrieved for one hour. 

# ✔️ Testing

Execute:
- `docker-compose up`; 
- Wait the initialization of MySQL;     
- `docker-compose run scrapper bash`
- `export YEAR=2022`
- `export USER=upxxxxxxxxx`  (change the x by your up number)
- `make` (this should trigger the scrapping) 
- `make upload` (upload the data to an online website. The data is deleted after one hour)
- `make clean` (check if the `scrapper/data` folder is empty) 

closes #29 