### PR TITLE
Fix shedule professor spyder

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -2,7 +2,7 @@
 # Change for the year you desire to scrap. 
 YEAR=2022
 # Change it to your UP number. 
-USER=up201800175
+USER=up202208700
 
 [pbar]
 # Configuration of the percentage bar.
@@ -31,7 +31,7 @@ num_courses=313
 num_course_units=6513
 num_course_metadata=8590
 num_schedules=11120
-num_schedule_professor=19273
+num_schedule_professor=42737
 num_professors=2688
 
 # !! Do NOT change this section !! 

--- a/src/scrapper/spiders/schedule_professor_spider.py
+++ b/src/scrapper/spiders/schedule_professor_spider.py
@@ -78,6 +78,7 @@ class ScheduleProfessorSpider(scrapy.Spider):
                 yield scrapy.http.Request(
                     url="https://sigarra.up.pt/{}/pt/hor_geral.composto_doc?p_c_doc={}".format(faculty, professor_sigarra_id),
                     meta={'schedule_id': schedule_id},
+                    dont_filter=True,
                     callback=self.extractCompoundProfessors)
             else:
             # It is the sigarra's professor id. 


### PR DESCRIPTION
The scrapper had a problem with class compounds: sometimes a schedule_professor was created just for the first class and not for any of the others.
This pull request fixes this issue. The problem was caused by the way Scrapy works. When a request is made and there's another request identical to the other in queue, it would be filtered and not performed. To fix this, we just needed to specify not to do this filtering.