### PR TITLE
Fix scrapy dependencies

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -28,3 +28,4 @@ Sphinx==6.1.3
 tornado==6.2
 tqdm==4.64.1
 urllib3_secure_extra==0.1.0
+Twisted==22.10.0


### PR DESCRIPTION
It seems that there's one scrapy dependency that updated that breaks scrapy on the current version. So we downgrade `Twister` version to the previous version: `22.10`