### PR TITLE
Fix bug where shared course units wouldn't show up

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -23,7 +23,7 @@ protobuf==4.22.0
 pyopenssl==22.0.0
 python_bcrypt==0.3.2
 railroad==0.5.0
-Scrapy==2.6.2
+Scrapy==2.7.0
 Sphinx==6.1.3
 tornado==6.2
 tqdm==4.64.1

--- a/src/scrapper/dupefilter.py
+++ b/src/scrapper/dupefilter.py
@@ -1,0 +1,7 @@
+import uuid
+
+class RequestFingerprinter:
+    def fingerprint(self, request):
+        # never return an equal value so that every request is scheduled
+        return uuid.uuid4().bytes
+        

--- a/src/scrapper/settings.py
+++ b/src/scrapper/settings.py
@@ -87,9 +87,11 @@ AUTOTHROTTLE_TARGET_CONCURRENCY = 128.0
 # Enable showing throttling stats for every response received:
 AUTOTHROTTLE_DEBUG = True
 
+REQUEST_FINGERPRINTER_CLASS = 'scrapper.dupefilter.RequestFingerprinter'
+
 # Enable and configure HTTP caching (disabled by default)
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
-#HTTPCACHE_ENABLED = True
+#HTTPCACHE_ENABLED = False
 #HTTPCACHE_EXPIRATION_SECS = 0
 #HTTPCACHE_DIR = 'httpcache'
 #HTTPCACHE_IGNORE_HTTP_CODES = []

--- a/src/scrapper/spiders/course_unit_spider.py
+++ b/src/scrapper/spiders/course_unit_spider.py
@@ -4,6 +4,7 @@ from scrapy.http import Request, FormRequest
 from urllib.parse import urlparse, parse_qs, urlencode
 from configparser import ConfigParser, ExtendedInterpolation
 from datetime import datetime
+import logging
 import json
 
 from ..database.Database import Database
@@ -29,6 +30,7 @@ class CourseUnitSpider(scrapy.Spider):
         super(CourseUnitSpider, self).__init__(*args, **kwargs)
         self.open_config()
         self.user = self.config['default']['USER']
+        logging.getLogger('scrapy').propagate = False
 
     def format_login_url(self):
         return '{}?{}'.format(self.login_page_base, urlencode({

--- a/src/scripts/dump/schema/create_db_sqlite3.sql
+++ b/src/scripts/dump/schema/create_db_sqlite3.sql
@@ -126,6 +126,7 @@ alter TABLE course ADD PRIMARY KEY (`id`);
 alter TABLE course ADD FOREIGN KEY (`faculty_id`) REFERENCES `faculty`(`acronym`) on DELETE CASCADE ON UPDATE CASCADE;
 
 alter TABLE course_unit ADD PRIMARY KEY (`id`);
+alter TABLE course_unit ADD UNIQUE (`sigarra_id`, `course_id`);
 alter TABLE course_unit ADD FOREIGN KEY (`course_id`) REFERENCES `course`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 alter TABLE course_metadata ADD PRIMARY KEY (`course_id`, `course_unit_id`, `course_unit_year`);


### PR DESCRIPTION
This does some nasty stuff on the scheduler (and practically removes the ability for the scheduler to remove duplicate Requests).

The root cause is that the relation course <--> course_unit is incorrect. It should be a many-to-many relationship instead of a 1-to-many relationship. To quickly fix this without redesigning the schema, we duplicate the course_unit but to a different course (ofc).  This causes everything that depends on course units (metadata, schedule) to be duplicated hence the need to disable the deduplication on the scrappy scheduler side.

To disable the scheduler, this PR also bumps Scrappy to 2.7.0, where this feature was added. 

**This nasty fix should be removed ASAP when we solve the schema issue and use the meta `no_filter` on course_unit requests instead.** 

For example, this Course Unit (Mecânica dos Solos) is shared between L.EMG and L.EC (https://sigarra.up.pt/feup/pt/ucurr_geral.ficha_uc_view?pv_ocorrencia_id=519393) 