### PR TITLE
fix: documentation now reflects new .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,57 @@
 # University of Porto Scrapper - *UPS!*
+
 Python solution to extract the courses schedules from the different Faculties of University of Porto.
 
 ## Requirements
+
 - docker-ce
 - docker-compose
-**or** 
+**or**
 - python >=3.8
-- make 
+- make
 
-**If you don't have docker**, you can use python locally in your machine **or** create a virtual environment. In this case make sure python version is `>=3.8`. 
+**If you don't have docker**, you can use python locally in your machine **or** create a virtual environment. In this case make sure python version is `>=3.8`.
 
-### Local python 
+### Local python
+
 ```bash
 pip install -r ./scr/requirements.txt   # Install dependencies
 ```
 
 ### Virtual environment
-```bash 
+
+```bash
 python -m venv venv_scrapper            # Create virtual environment
 source ./venv_scrapper/bin/activate        # Activate virtual environment
 pip install -r ./src/requirements.txt   # Install dependencies
 ```
 
-
 ## Quick start
 
 ### :wrench: Configure
-Change the following fields in `./src/config.ini`: 
-- `USER`: replace with your `up` number (e.g `up201812345`).
-- `YEAR`: replace with the year you want to scrap (e.g. 2022 is for the 2022/2023 school year).
 
-```ini
-[default]
-YEAR=2022
-USER=up201800175
+1. Create a `.env` example from the `.env.example` file
+
+```bash
+cd src && cp .env.example .env
+```
+
+2. Change the following fields in the `.env` file:
+
+- `TTS_SCRAPY_USER`: replace with your `up` number (e.g `up201812345`).
+- `TTS_SCRAPY_YEAR`: replace with the year you want to scrap (e.g. 2022 is for the 2022/2023 school year).
+- `TTS_SCRAPY_PASSWORD`: replace with your `sigarra` password.
+
+```env
+TTS_SCRAPY_YEAR=2023
+TTS_SCRAPY_USER=username
+TTS_SCRAPY_PASSWORD=password
 ```
 
 ### :dash: Run
-- Gathering data: 
+
+- Gathering data:
+
 ```bash
 docker-compose run scrapper make
 # or 
@@ -45,6 +59,7 @@ cd ./src && make
 ```
 
 - Dumping data:
+
 ```bash
 docker-compose run scrapper make dump
 # or 
@@ -52,25 +67,27 @@ cd ./src && make dump
 ```
 
 - Upload data to temporary online storage:
+
 ```bash
 docker-compose run scrapper make upload
 # or 
 cd ./src && make upload
 ```
 
-- Clean database: 
+- Clean database:
+
 ```bash
 docker-compose run scrapper make clean
 # or
 cd ./src && make clean
 ```
 
-
-## :mag: Inspect 
+## :mag: Inspect
 
 To inspect the scrapy engine, use `scrapy shell "url"`
 
 Example:
+
 ```
 root@00723f950c71:/scrapper# scrapy shell "https://sigarra.up.pt/fcnaup/pt/cur_geral.cur_planos_estudos_view?pv_plano_id=2523&pv_ano_lectivo=2017&pv_tipo_cur_sigla=D&pv_origem=CUR"
 2017-10-24 20:51:35 [scrapy.utils.log] INFO: Scrapy 1.4.0 started (bot: scrapper)
@@ -80,12 +97,12 @@ root@00723f950c71:/scrapper# scrapy shell "https://sigarra.up.pt/fcnaup/pt/cur_g
 >>> response.xpath('//*[@id="anos_curr_div"]/div').extract()
 ```
 
-## :triangular_ruler: Database design 
+## :triangular_ruler: Database design
 
 ![Image](./docs/schema.2.0.png)
 
+## :page_with_curl: More information
 
-## :page_with_curl: More information 
-- This repository contains useful scripts. Check the  `./src/scripts` folder. 
-- For some information of how the `sqlite3` database is generated check the `./src/scrapper/database/dbs` folder. 
-- Configurations can be done in the `./src/config.ini` file. 
+- This repository contains useful scripts. Check the  `./src/scripts` folder.
+- For some information of how the `sqlite3` database is generated check the `./src/scrapper/database/dbs` folder.
+- Configurations can be done in the `./src/config.ini` file.


### PR DESCRIPTION
When the pr #102 was merged, I forgot to change the `Configuration` part of the README file and it is still saying that we must configure by writing to the `config.ini` file.

This PR aims to fix that problem.