### PR TITLE
SQL dump now has column names and fixed cases where `professor_id` was NULL

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,8 +33,8 @@ upload:
 	@python ./scripts/upload.py
 	@echo "Upload completed!"
 
-convert_mysql:
-	@echo "Converting dump to mysql..."
+convert_postgres:
+	@echo "Converting dump to postgres..."
 	@bash ./scripts/sqlite3-to-mysql.sh ./scripts/dump/data/dump_sqlite3.sql > ./scripts/dump/data/01_data.sql
 	@echo "Convertion completed!"
 

--- a/src/scrapper/spiders/slot_spider.py
+++ b/src/scrapper/spiders/slot_spider.py
@@ -225,6 +225,11 @@ class SlotSpider(scrapy.Spider):
             [professor_sigarra_id, professor_name,
                 *_] = teacher["name"].split("-", 1)
 
-            return (professor_sigarra_id.strip(), professor_name.strip())
+            try:
+                professor_sigarra_id = int(professor_sigarra_id.strip())
+            except:
+                professor_sigarra_id = teacher["id"]
+
+            return (professor_sigarra_id, professor_name.strip())
 
         return (teacher["sigarra_id"], teacher["name"])

--- a/src/scripts/dump.py
+++ b/src/scripts/dump.py
@@ -42,9 +42,16 @@ class Dump:
         f.close()
 
     def dump_table(self, table, con, f):
+        cursor = con.cursor()
+        cursor.execute("PRAGMA table_info({})".format(table))
+
+        columns = [row[1] for row in cursor.fetchall()]
+
         for line in con.iterdump():
             if line.startswith("INSERT") and "\"{}\"".format(table) in line:
-                f.write('%s\n' % line)
+                insert_stmt = "INSERT INTO {} ({}) VALUES ".format(table, ", ".join(columns))
+                values = line.split("VALUES")[1].strip()
+                f.write(insert_stmt + values + "\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The fact that the sql dump now has column names means that the inserts now look like this:

`INSERT INTO slot_professor (slot_id, professor_id) VALUES (4, 5)`

This was done in order to remove the need to always have the table attributes of the database schema in order with the schemas from the scrapper.

Also, there were some `INSERTS` into the `slot_professor` table where the `professor_id` was a string. That was because now there was a change to the sigarra schedule's API and some  classes with no professores had names like: `DEEC - blah blah`, which messed up the initial regex to separate cases where there were no professors. Now, with this pr, all of the cases result in the `professor_id` being a int